### PR TITLE
fix: set local winhl option instead of global one

### DIFF
--- a/lua/neo-term/init.lua
+++ b/lua/neo-term/init.lua
@@ -23,6 +23,8 @@ end
 function M.setup(opts)
   if not opts then opts = {} end
 
+  vim.api.nvim_set_hl(0, 'NEO_TERM_COOL_BLACK', { bg = '#101010' })
+
   M.term_mode_hl = opts.term_mode_hl or 'NEO_TERM_COOL_BLACK'
     if type(M.term_mode_hl) ~= 'string' then M.term_mode_hl = 'NEO_TERM_COOL_BLACK' end
   M.exclude_filetypes = U.table_add_values({ 'git.*' },

--- a/lua/neo-term/utils/autocmd.lua
+++ b/lua/neo-term/utils/autocmd.lua
@@ -59,7 +59,6 @@ local function create_features_autocmds()
       if vim.bo.filetype ~= 'neo-term'
         or vim.bo.buftype ~= 'terminal'
       then return end
-      vim.cmd('hi NEO_TERM_COOL_BLACK guibg=#101010')
       vim.cmd('set winhl=Normal:' .. (require('neo-term').term_mode_hl or 'NEO_TERM_COOL_BLACK'))
     end
   })

--- a/lua/neo-term/utils/autocmd.lua
+++ b/lua/neo-term/utils/autocmd.lua
@@ -59,7 +59,9 @@ local function create_features_autocmds()
       if vim.bo.filetype ~= 'neo-term'
         or vim.bo.buftype ~= 'terminal'
       then return end
-      vim.cmd('set winhl=Normal:' .. (require('neo-term').term_mode_hl or 'NEO_TERM_COOL_BLACK'))
+      vim.opt_local.winhighlight = {
+        Normal = require('neo-term').term_mode_hl or 'NEO_TERM_COOL_BLACK',
+      }
     end
   })
   -- reset bg-color on leave term-mode of NeoTerm.
@@ -70,7 +72,7 @@ local function create_features_autocmds()
       if vim.bo.filetype ~= 'neo-term'
         or vim.bo.buftype ~= 'terminal'
       then return end
-      vim.cmd('set winhl=')
+      vim.opt_local.winhighlight = {}
     end
   })
   -- auto-insert on enter term-buf of NeoTerm.


### PR DESCRIPTION
The current build uses `set winhighlight=...` and it changes setting for all windows after one NeoTerm buffer is opened. This fixes it (2c44c90).

In addition, it also includes one small fix (74c74e1).